### PR TITLE
Added :views option to exception render

### DIFF
--- a/lib/padrino-contrib/exception_notifier.rb
+++ b/lib/padrino-contrib/exception_notifier.rb
@@ -24,6 +24,7 @@ module Padrino
         app.set :exceptions_to,      "errors@localhost.local" unless app.respond_to?(:exceptions_to)
         app.set :exceptions_from,    "foo@bar.local" unless app.respond_to?(:exceptions_from)
         app.set :exceptions_layout,  :layout unless app.respond_to?(:exceptions_layout)
+        app.set :exceptions_views,   app.views unless app.respond_to?(:exceptions_views)
         app.set :redmine, {} unless app.respond_to?(:redmine)
         app.error 500 do
           boom  = env['sinatra.error']
@@ -42,12 +43,12 @@ module Padrino
           end
           response.status = 500
           content_type 'text/html', :charset => "utf-8"
-          render settings.exceptions_page, :layout => settings.exceptions_layout
+          render settings.exceptions_page, :layout => settings.exceptions_layout, :views => settings.exceptions_views
         end
         app.error 404 do
           response.status = 404
           content_type 'text/html', :charset => "utf-8"
-          render settings.exceptions_page, :layout => settings.exceptions_layout
+          render settings.exceptions_page, :layout => settings.exceptions_layout, :views => settings.exceptions_layout
         end
       end # self.registered
     end # ExceptionNotifier


### PR DESCRIPTION
In my padrino application, my 404 and 500 pages are shared among all apps and located in the public folder. I accomplish this by passing the public_folder directory to the `:views` option in the render method in my app's error management.

``` ruby
error 404 do
  render "404.haml", :views => App.public_folder
end
```

This could be an invalid approach but in keeping with this approach, the exception_notifier_plugin does not support passing along a `:views` parameter.

I resolved the issue by adding the `:exceptions_views` option to the **exception_notifier.rb** file.

``` ruby
def self.registered(app)
  ...
  app.set :exceptions_layout,  :layout unless app.respond_to?(:exceptions_layout)
  app.set :exceptions_views,   app.views unless app.respond_to?(:exceptions_views)
  app.set :redmine, {} unless app.respond_to?(:redmine)
  ...
  app.error 500 do
    ...
    content_type 'text/html', :charset => "utf-8"
    render settings.exceptions_page, :layout => settings.exceptions_layout, :views => settings.exceptions_views
  end
  app.error 404 do
    response.status = 404
    content_type 'text/html', :charset => "utf-8"
    render settings.exceptions_page, :layout => settings.exceptions_layout, :views => settings.exceptions_layout
  end
end
```

Please let me know if I'm approaching this incorrectly, and if so, a link to the right approach.

Thanks,
Blake
