### PR TITLE
Updated deprecated skip_bundler method for RSpec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,8 +21,7 @@ end
 task :release => :bump
 
 desc "Run complete application spec suite"
-RSpec::Core::RakeTask.new("spec") do |t|
-  t.skip_bundler = true
+RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = './spec/**/*_spec.rb'
   t.rspec_opts = %w(-fs --color --fail-fast)
 end


### PR DESCRIPTION
Per the RSpec source (https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/rake_task.rb)

```
      # @deprecated
      # Has no effect. The rake task now checks ENV['BUNDLE_GEMFILE'] instead.
```

and fixes a deprecated warning.
