### PR TITLE
Hello? Anyone still maintain this project? Routing of auto-locale is broken. It needs fix.

### DIFF
--- a/lib/padrino-contrib/auto_locale.rb
+++ b/lib/padrino-contrib/auto_locale.rb
@@ -40,7 +40,11 @@ module Padrino
         end
 
         def self.padrino_route_added(route, verb, path, args, options, block)
-          route.instance_variable_set(:@original_path, "/:lang#{route.original_path}") unless route.original_path =~/:lang/
+          ##
+          # TODO: Regex original_path needs to be served as well.
+          #
+          return unless route.original_path.is_a?(String)
+          route.path = "/:lang#{route.original_path}" unless route.original_path.empty? or route.original_path =~/:lang/
         end
       end
 


### PR DESCRIPTION
The old code is two years ago. Now padrino's routing has changed. The code doesn't work any more. I fixed it by calling the path= method to set the new "/:lang/..." path, instead of set it to the @original_path variable(which doesn't take effect at all now).

Auto-Locale is an elegant implementation. It is useful for i18n website, especially which needs "/en/url", "/zh_cn/url" url-style to get better SEO. Please merge this commit to master and let's make Auto-Locale live again!

Thank you!
