### PR TITLE
Exceptions filtering for nested params

### DIFF
--- a/lib/padrino-contrib/exception_notifier.rb
+++ b/lib/padrino-contrib/exception_notifier.rb
@@ -34,10 +34,15 @@ module Padrino
           env.each { |k,v| body += "\n#{k}: #{v}" }
           body += "\n\n---Params:\n"
           params.each do |k,v|
-            if settings.exceptions_params_filter.include?(k)
-              body += "\n#{k.inspect} => [FILTERED]"
+            if v.is_a? Hash
+              (settings.exceptions_params_filter & v.keys).each{ |key| v.merge! key => '[FILTERED]' }
+              body += "\n#{k.inspect} => { #{v.map{ |k,v| "#{k.inspect} => #{v == '[FILTERED]' ? v.chomp : v.inspect}" }.join(', ')} }"
             else
-              body += "\n#{k.inspect} => #{v.inspect}"
+              if settings.exceptions_params_filter.include?(k)
+                body += "\n#{k.inspect} => [FILTERED]"
+              else
+                body += "\n#{k.inspect} => #{v.inspect}"
+              end
             end
           end
           logger.error body

--- a/spec/exception_notifier_spec.rb
+++ b/spec/exception_notifier_spec.rb
@@ -62,6 +62,15 @@ describe Padrino::Contrib::ExceptionNotifier do
       expect(last_email.body).to match /"foo" => \[FILTERED\]/
     end
 
+    it 'allows filtering of nested request params' do
+      get '/boom', { :account => { :email => 'foo@example.com',
+                                   :password => 'super_secret',
+                                   :password_confirmation => 'super_secret' }
+                    }
+      expect(last_email.body).to match /"password" => \[FILTERED\]/
+      expect(last_email.body).to match /"password_confirmation" => \[FILTERED\]/
+    end
+
     it 'renders an error page' do
       get '/boom'
       expect(last_response.status).to eq 500


### PR DESCRIPTION
Params filtering currently only accepts flat hash, but I reckoned there are times when using the 'form_for' tag the values are submitted as a nested hash and wouldn't get filtered.

For e.g
{:account => { :password => 'secrets' }}, the password would still remain as plain text.
