### PR TITLE
Added support for passenger_base_uri to auto_locale

### DIFF
--- a/lib/padrino-contrib/auto_locale.rb
+++ b/lib/padrino-contrib/auto_locale.rb
@@ -24,8 +24,8 @@ module Padrino
         #
         def switch_to_lang(lang)
           return unless settings.locales.include?(lang)
-          return "/#{lang}" if request.path_info == '/'
-          request.path_info.sub(/\/#{I18n.locale}/, "/#{lang}")
+          return url("/#{lang}", false) if request.path_info == '/'
+          url(request.path_info.sub(/\/#{I18n.locale}/, "/#{lang}"), false)
         end
       end # Helpers
 
@@ -70,7 +70,7 @@ module Padrino
               end
             end
             # Then redirect from "/" to "/:lang" to match the new routing urls
-            redirect "/#{I18n.locale.to_s}/"
+            redirect url("/#{I18n.locale.to_s}/", false)
 
           # Return 404 not found for everything else
           else


### PR DESCRIPTION
I use nginx and passenger, and passenger_base_uri.
But auto_locale remove passenger_base_uri from the path.

e.g. There are two padrino projects ( app1 and app2).

```
server {
  server_name www.example.com;
  passenger_base_uri /app1;
  passenger_base_uri /app2;
  ...
}
```

result:

```
[ access to http://www.example.com/app1/ ] -> [ redirect ] -> http://www.example.com/en/
http://www.example.com/app1/en/ -> [ switch_to_lang(:ja) ] -> http://www.example.com/ja/
http://www.example.com/app2/en/ -> [ switch_to_lang(:ja) ] -> http://www.example.com/ja/
```

We should use url([ target_path ], false) or request.script_name in auto_locale.
