### PR TITLE
Fix warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ group :test do
   gem 'padrino-mailer'
   gem 'rspec'
   gem 'rack-test'
-  gem 'webrat'
+  gem 'oga'
 end

--- a/lib/padrino-contrib/helpers/jquery.rb
+++ b/lib/padrino-contrib/helpers/jquery.rb
@@ -51,7 +51,7 @@ module Padrino
                     source.sub!(cr,'')
                   end
                   # Removes empty lines
-                  source.each_line.reject { |l| l.strip == "" }.join
+                  source.each_line.reject { |line| line.strip == "" }.join
                 end
                 File.open(path, "w") { |f| f.write sources.join("\n") }
                 logger.debug "JQuery Cached (%0.2fms) %s" % [Time.now-began_at, path] if defined?(logger)

--- a/spec/auto_locale_spec.rb
+++ b/spec/auto_locale_spec.rb
@@ -39,7 +39,7 @@ describe Padrino::Contrib::AutoLocale do
     it "doesn't choke when the HTTP_ACCEPT_LANGUAGE header is not present" do
       expect do
         get '/', { }, 'HTTP_ACCEPT_LANGUAGE' => nil
-      end.not_to raise_exception NoMethodError
+      end.not_to raise_error
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,11 @@ require 'rubygems' unless defined?(Gem)
 require 'bundler'
 Bundler.require(:default, RACK_ENV)
 
+require_relative 'support/matchers/have_selector'
 require 'padrino-contrib'
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods
-  config.include Webrat::Matchers
 
   # Sets up a Sinatra::Base subclass defined with the block
   # given. Used in setup or individual spec methods to establish

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
-PADRINO_ENV = 'test'
+RACK_ENV = 'test'
 PADRINO_ROOT = File.dirname(__FILE__) unless defined?(PADRINO_ROOT)
 require 'rubygems' unless defined?(Gem)
 require 'bundler'
-Bundler.require(:default, PADRINO_ENV)
+Bundler.require(:default, RACK_ENV)
 
 require 'padrino-contrib'
 

--- a/spec/support/matchers/have_selector.rb
+++ b/spec/support/matchers/have_selector.rb
@@ -1,0 +1,23 @@
+RSpec::Matchers.define :have_selector do |selector, attributes|
+  match do |actual|
+    tags = html_matched_tags(actual, selector, attributes)
+    tags.count > 0
+  end
+
+  def html_matched_tags(html, selector, attributes)
+    dom = Oga.parse_html(html)
+
+    selector = selector.to_s
+    content_requirement = attributes.delete(:content)
+    attributes.each do |name, value|
+      selector += %{[#{name}="#{value}"]}
+    end
+    tags = dom.css(selector.to_s.gsub(/\[([^"']*?)=([^'"]*?)\]/, '[\1="\2"]'))
+    if content_requirement
+      tags = tags.select{ |tag| (tag.get('content') || tag.text).index(content_requirement) }
+    end
+
+    tags
+  end
+end
+


### PR DESCRIPTION
Running the specs caused some warnings to be emitted.

The largest change is the switch from Webrat to Oga+a custom RSpec matcher. Webrat hasn't been touched in years and was using legacy RSpec functionality.